### PR TITLE
fix: adjust base path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : './',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure Vite uses a relative base path in production so built assets load on GitHub Pages
- load entry script using a relative path in `index.html`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a65a26a814832da612761821bf6747