### PR TITLE
feat: support images in questions

### DIFF
--- a/src/components/QuestionPanel.tsx
+++ b/src/components/QuestionPanel.tsx
@@ -12,6 +12,7 @@ interface Question {
   topic?: string;
   difficulty?: string;
   explanation?: string;
+  image_url?: string;
 }
 
 interface Attempt {
@@ -22,6 +23,7 @@ interface Attempt {
 
 interface QuestionPanelProps {
   question: Question;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   session: any;
   attempt: Attempt | null;
   onAnswer: (choiceIndex: number) => void;
@@ -57,6 +59,16 @@ export function QuestionPanel({
         <div className="text-lg font-semibold leading-relaxed">
           {question.stem}
         </div>
+
+        {question.image_url && (
+          <div className="flex justify-center">
+            <img
+              src={question.image_url}
+              alt="Question illustration"
+              className="max-h-64 w-full object-contain rounded"
+            />
+          </div>
+        )}
 
         <div className="grid gap-2">
           {question.choices?.map((choice, index) => {

--- a/src/components/ReviewPanel.tsx
+++ b/src/components/ReviewPanel.tsx
@@ -9,6 +9,7 @@ interface Question {
   topic?: string;
   difficulty?: string;
   explanation?: string;
+  image_url?: string;
 }
 
 interface ReviewPanelProps {
@@ -51,11 +52,19 @@ export function ReviewPanel({ incorrectQuestions }: ReviewPanelProps) {
                     <Badge variant="secondary">{question.difficulty}</Badge>
                   )}
                 </div>
-                
+
                 <div className="font-medium">
                   {question.stem}
                 </div>
-                
+
+                {question.image_url && (
+                  <img
+                    src={question.image_url}
+                    alt="Question illustration"
+                    className="max-h-64 w-full object-contain rounded"
+                  />
+                )}
+
                 <div className="text-sm">
                   <span className="text-muted-foreground">Correct answer: </span>
                   <span className="font-medium text-success">

--- a/src/components/SessionControls.tsx
+++ b/src/components/SessionControls.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
 interface SessionControlsProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   session: any;
   onCreateSession: (topic: string | null, mode: string) => void;
   onResumeSession: () => void;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,6 +17,7 @@ interface Question {
   difficulty?: string;
   explanation?: string;
   is_active: boolean;
+  image_url?: string;
 }
 
 interface Session {
@@ -55,12 +56,19 @@ const Index = () => {
   const [incorrectQuestions, setIncorrectQuestions] = useState<Question[]>([]);
   const { toast } = useToast();
 
+  // dbQuestion comes directly from Supabase and may have any shape
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const convertToQuestion = (dbQuestion: any): Question => ({
     ...dbQuestion,
-    choices: Array.isArray(dbQuestion.choices) ? dbQuestion.choices.filter((c: any) => typeof c === 'string') : [],
+    choices: Array.isArray(dbQuestion.choices)
+      ? dbQuestion.choices.filter(
+          (c: unknown): c is string => typeof c === "string"
+        )
+      : [],
     topic: dbQuestion.topic || undefined,
     difficulty: dbQuestion.difficulty || undefined,
     explanation: dbQuestion.explanation || undefined,
+    image_url: dbQuestion.image_url || undefined,
   });
 
   const fetchActiveQuestions = async (topic?: string): Promise<Question[]> => {
@@ -149,10 +157,11 @@ const Index = () => {
         title: "New session created",
         description: `Started ${mode} with ${questionIds.length} questions.`,
       });
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -206,10 +215,11 @@ const Index = () => {
         title: "Session resumed",
         description: `Resumed ${sessionData.mode} session.`,
       });
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -267,10 +277,11 @@ const Index = () => {
       if (sessionError) throw sessionError;
 
       setSession(sessionData);
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -319,10 +330,11 @@ const Index = () => {
         title: "Session completed",
         description: `Final score: ${data.score}/${data.total}`,
       });
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }

--- a/src/pages/Testing.tsx
+++ b/src/pages/Testing.tsx
@@ -19,6 +19,7 @@ interface Question {
   difficulty?: string;
   explanation?: string;
   is_active: boolean;
+  image_url?: string;
 }
 
 const Testing = () => {
@@ -29,6 +30,7 @@ const Testing = () => {
     topic: "",
     difficulty: "",
     explanation: "",
+    image_url: "",
   });
   const [existingQuestions, setExistingQuestions] = useState<Question[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -62,6 +64,7 @@ const Testing = () => {
         topic: newQuestion.topic || null,
         difficulty: newQuestion.difficulty || null,
         explanation: newQuestion.explanation || null,
+        image_url: newQuestion.image_url || null,
         is_active: true,
       });
 
@@ -80,14 +83,16 @@ const Testing = () => {
         topic: "",
         difficulty: "",
         explanation: "",
+        image_url: "",
       });
 
       // Refresh questions list
       loadExistingQuestions();
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -107,17 +112,21 @@ const Testing = () => {
 
       const questions = (data || []).map(q => ({
         ...q,
-        choices: Array.isArray(q.choices) ? q.choices.filter((c: any) => typeof c === 'string') : [],
+        choices: Array.isArray(q.choices)
+          ? q.choices.filter((c: unknown): c is string => typeof c === "string")
+          : [],
         topic: q.topic || undefined,
         difficulty: q.difficulty || undefined,
         explanation: q.explanation || undefined,
+        image_url: q.image_url || undefined,
       }));
 
       setExistingQuestions(questions);
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -181,10 +190,11 @@ const Testing = () => {
       });
 
       loadExistingQuestions();
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -202,10 +212,11 @@ const Testing = () => {
         title: "Database Connection",
         description: "✅ Successfully connected to Supabase!",
       });
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: "Database Error",
-        description: error.message,
+        description: message,
         variant: "destructive",
       });
     }
@@ -349,6 +360,16 @@ const Testing = () => {
                   />
                 </div>
 
+                <div>
+                  <label className="text-sm font-medium">Image URL (Optional)</label>
+                  <Input
+                    placeholder="https://example.com/image.jpg"
+                    value={newQuestion.image_url}
+                    onChange={(e) => setNewQuestion({ ...newQuestion, image_url: e.target.value })}
+                    className="mt-1"
+                  />
+                </div>
+
                 <Button onClick={addSampleQuestion} disabled={isLoading} className="w-full">
                   {isLoading ? "Adding..." : "Add Question"}
                 </Button>
@@ -386,7 +407,15 @@ const Testing = () => {
                             </div>
                             
                             <div className="font-medium">{question.stem}</div>
-                            
+
+                            {question.image_url && (
+                              <img
+                                src={question.image_url}
+                                alt="Question illustration"
+                                className="max-h-64 w-full object-contain rounded"
+                              />
+                            )}
+
                             <div className="grid gap-1">
                               {question.choices.map((choice, index) => (
                                 <div

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -100,5 +101,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- allow questions to include optional image URLs
- render question images in quiz and review panels
- enable adding question images in testing interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a668849188832da5006fe20ebf1f48