### PR TITLE
feat: configure GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ npm run lint
 npm run build
 ```
 
+## Deploy to GitHub Pages
+
+1. Build the project:
+
+   ```sh
+   npm run build
+   ```
+
+2. Push the contents of `dist/` to a `gh-pages` branch:
+
+   ```sh
+   git subtree push --prefix dist origin gh-pages
+   ```
+
+3. Enable GitHub Pages in the repository settings, pointing to the `gh-pages` branch.
+
+The app is configured with a production base path of `/ascpi-quest-pro/` and uses a hash-based router for client-side navigation.
+
 ## Architecture
 
 - React components live in `src/components` and page-level views live in `src/pages`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import Testing from "./pages/Testing";
 import NotFound from "./pages/NotFound";
 
@@ -13,14 +13,14 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <HashRouter>
         <Routes>
           <Route path="/" element={<Testing />} />
           <Route path="/testing" element={<Testing />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
+      </HashRouter>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === 'development' ? '/' : './',
+  base: mode === "development" ? "/" : "/ascpi-quest-pro/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set Vite base path for GitHub Pages
- switch to hash-based routing for static hosting
- document deployment steps for GitHub Pages

## Testing
- `npm run lint` *(fails: Unexpected any / require imports)*
- `npx eslint vite.config.ts src/App.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a667f62778832da22d36d9e061f40f